### PR TITLE
Fix url for comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Parameters:
 
 #### Adding a comment
 
-POST [https://theoldreader.com/reader/api/0/comments/edit](https://theoldreader.com/reader/api/0/comments/edit)
+POST [https://theoldreader.com/reader/api/0/comment/edit](https://theoldreader.com/reader/api/0/comment/edit)
 
 Parameters:
 


### PR DESCRIPTION
It looks like /comments/edit is 404, as /comment/edit give result, i think it is the real url.
